### PR TITLE
Remove nonexistent dependency

### DIFF
--- a/Assets/Scripts/UI/ItemData.cs
+++ b/Assets/Scripts/UI/ItemData.cs
@@ -1,6 +1,4 @@
-using Codice.Client.BaseCommands.Merge.Xml;
 using UnityEngine;
-using UnityEngine.Tilemaps;
 
 namespace GoopGame.Engine
 {


### PR DESCRIPTION
VisualStudio will frequently auto-add namespaces that do not exist in our project (thanks AI). These have to be removed as we cannot build if there are any such namespaces.